### PR TITLE
Update yarn.lock & webpack config

### DIFF
--- a/examples/browser/webpack.config.js
+++ b/examples/browser/webpack.config.js
@@ -5,14 +5,4 @@
 // @ts-check
 const config = require('./gen-webpack.config.js');
 
-/**
- * Expose bundled modules on window.theia.moduleName namespace, e.g.
- * window['theia']['@theia/core/lib/common/uri'].
- * Such syntax can be used by external code, for instance, for testing.
- */
-config.module.rules.push({
-    test: /\.js$/,
-    loader: require.resolve('@theia/application-manager/lib/expose-loader')
-});
-
 module.exports = config;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3120,7 +3120,7 @@
     "@types/node" "*"
     form-data "^3.0.0"
 
-"@types/node@*", "@types/node@12", "@types/node@14.x", "@types/node@>=10.0.0", "@types/node@^14.6.2", "@types/node@~12":
+"@types/node@*", "@types/node@12", "@types/node@14.x", "@types/node@>=10.0.0", "@types/node@^14.6.2":
   version "12.20.55"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==


### PR DESCRIPTION
The webpack config contains an outdated rule entry. In the theia generator, this webpack rule is outcommented so we do the same here.

Contributed on behalf of STMicroelectronics.